### PR TITLE
Fix stored URL paths for published posts in 'path'-URL-type blogs

### DIFF
--- a/commands/publish.js
+++ b/commands/publish.js
@@ -130,7 +130,7 @@ function publish(args) {
         }
 
         baseDir = (urlType == "path") ? getBaseDir(draftPath, isDirectory) : getDateDir();
-        shortPubPath = baseDir + '/';
+        shortPubPath = baseDir.length ? baseDir + '/' : '';
         pubPath = pdir(baseDir);
         srcPubPath = path.join(dirs.srcPublished, baseDir);
 

--- a/commands/publish.js
+++ b/commands/publish.js
@@ -302,7 +302,7 @@ publish.mixinData = function (srcPath, publishData) {
 };
 
 publish.renderPost = function (srcPath, publishedData) {
-    var postPath, srcDir;
+    var postPath, srcDir, postTemplate, parentCount, rootPath;
 
     if (fs.statSync(srcPath).isDirectory()) {
         srcDir = srcPath;
@@ -318,8 +318,19 @@ publish.renderPost = function (srcPath, publishedData) {
     }
 
     //Write out the post in HTML form.
-    convert(templates.text.year.month.day.title.index_html, publishedData,
-            path.join(postPath, 'index.html'), '../../../..');
+    if (publishedData.headers.template) {
+        postTemplate = resolveTemplate(publishedData.headers.template, templates.text);
+    }
+    if (!postTemplate) {
+        postTemplate = templates.text.year.month.day.title[templateField];
+    }
+
+    //Figure out how deeply nested the post is, to determine the rootPath value
+    parentCount = publishedData.url.replace(meta.data.url, '').split('/').length - 1;
+    rootPath = (new Array(parentCount + 1)).join('../').slice(0, -1);
+
+    convert(postTemplate, publishedData,
+            path.join(postPath, 'index.html'), rootPath);
 };
 
 publish.summary = 'Publishes a draft post in the "drafts" folder to ' +


### PR DESCRIPTION
EDIT: I seem to have gotten over eager in a push I did, and I kind of wrecked the two pull requests I have outstanding. I'm closing them and will fix things up before re-submitting. Sorry for the noise!

I'm making more progress on my own flavor of delposto, and I discovered that I left a bug in the last pull request. As submitted, when the `postUrlType` is `path`, we end up with a leading slash when publishing posts in the site root (nested post paths are unaffected), and this ends up creating incorrect template output. The fix is a simple one-liner, to simply avoid appending a slash onto the computed path if the post's base directory is `''`.
