### PR TITLE
Fix generated URLs for posts in the site root, as well as `rootPath` values for 'path'-type blogs

### DIFF
--- a/commands/publish.js
+++ b/commands/publish.js
@@ -302,7 +302,7 @@ publish.mixinData = function (srcPath, publishData) {
 };
 
 publish.renderPost = function (srcPath, publishedData) {
-    var postPath, srcDir;
+    var postPath, srcDir, parentCount, rootPath;
 
     if (fs.statSync(srcPath).isDirectory()) {
         srcDir = srcPath;
@@ -317,9 +317,13 @@ publish.renderPost = function (srcPath, publishedData) {
         file.copyDir(srcDir, postPath, null, null, /index\.md/);
     }
 
+    //Figure out how deeply nested the post is, to determine the rootPath value
+    parentCount = publishedData.url.replace(meta.data.url, '').split('/').length - 1;
+    rootPath = (new Array(parentCount + 1)).join('../').slice(0, -1);
+
     //Write out the post in HTML form.
     convert(templates.text.year.month.day.title.index_html, publishedData,
-            path.join(postPath, 'index.html'), '../../../..');
+            path.join(postPath, 'index.html'), rootPath);
 };
 
 publish.summary = 'Publishes a draft post in the "drafts" folder to ' +

--- a/commands/publish.js
+++ b/commands/publish.js
@@ -130,7 +130,7 @@ function publish(args) {
         }
 
         baseDir = (urlType == "path") ? getBaseDir(draftPath, isDirectory) : getDateDir();
-        shortPubPath = baseDir + '/';
+        shortPubPath = baseDir.length ? baseDir + '/' : '';
         pubPath = pdir(baseDir);
         srcPubPath = path.join(dirs.srcPublished, baseDir);
 

--- a/commands/publish.js
+++ b/commands/publish.js
@@ -302,7 +302,7 @@ publish.mixinData = function (srcPath, publishData) {
 };
 
 publish.renderPost = function (srcPath, publishedData) {
-    var postPath, srcDir;
+    var postPath, srcDir, postTemplate, parentCount, rootPath;
 
     if (fs.statSync(srcPath).isDirectory()) {
         srcDir = srcPath;
@@ -318,8 +318,19 @@ publish.renderPost = function (srcPath, publishedData) {
     }
 
     //Write out the post in HTML form.
-    convert(templates.text.year.month.day.title.index_html, publishedData,
-            path.join(postPath, 'index.html'), '../../../..');
+    if (publishedData.headers.template) {
+        postTemplate = resolveTemplate(publishedData.headers.template, templates.text);
+    }
+    if (!postTemplate) {
+        postTemplate = templates.text.year.month.day.title[templateField];
+    }
+
+    //Figure out how deeply nested the post is, to determine the rootPath value
+    parentCount = publishedData.url.replace(meta.data.url, '').split('/').length - 1;
+    rootPath = (new Array(parentCount + 1)).join('../').slice(0, -1);
+
+    convert(postTemplate, publishedData,
+            path.join(postPath, 'index.html'), rootPath);
 };
 
 publish.summary = 'Publishes a draft post in the "drafts" folder to ' +

--- a/commands/publish.js
+++ b/commands/publish.js
@@ -302,7 +302,7 @@ publish.mixinData = function (srcPath, publishData) {
 };
 
 publish.renderPost = function (srcPath, publishedData) {
-    var postPath, srcDir, postTemplate, parentCount, rootPath;
+    var postPath, srcDir;
 
     if (fs.statSync(srcPath).isDirectory()) {
         srcDir = srcPath;
@@ -318,19 +318,8 @@ publish.renderPost = function (srcPath, publishedData) {
     }
 
     //Write out the post in HTML form.
-    if (publishedData.headers.template) {
-        postTemplate = resolveTemplate(publishedData.headers.template, templates.text);
-    }
-    if (!postTemplate) {
-        postTemplate = templates.text.year.month.day.title[templateField];
-    }
-
-    //Figure out how deeply nested the post is, to determine the rootPath value
-    parentCount = publishedData.url.replace(meta.data.url, '').split('/').length - 1;
-    rootPath = (new Array(parentCount + 1)).join('../').slice(0, -1);
-
-    convert(postTemplate, publishedData,
-            path.join(postPath, 'index.html'), rootPath);
+    convert(templates.text.year.month.day.title.index_html, publishedData,
+            path.join(postPath, 'index.html'), '../../../..');
 };
 
 publish.summary = 'Publishes a draft post in the "drafts" folder to ' +


### PR DESCRIPTION
OK, I fixed up my broken stuff; here's the correct version of #3, which has comments describing the changes. Essentially, what we have here are two fixes for 'path'-type blogs, to correctly generate post URLs when they're in the root of the site, and to correctly generate the `rootPath` value for templates that need it.
