### PR TITLE
Allow posts to specify custom templates

### DIFF
--- a/commands/publish.js
+++ b/commands/publish.js
@@ -343,7 +343,7 @@ publish.renderPost = function (srcPath, publishedData) {
         postTemplate = resolveTemplate(publishedData.headers.template, templates.text);
     }
     if (!postTemplate) {
-        postTemplate = templates.text.year.month.day.title[templateField];
+        postTemplate = templates.text.year.month.day.title.index_html;
     }
     convert(postTemplate, publishedData,
             path.join(postPath, 'index.html'), '../../../..');

--- a/commands/publish.js
+++ b/commands/publish.js
@@ -61,6 +61,27 @@ function getBaseDir(draftPath, isDirectory) {
     return parts.join("/");
 }
 
+function resolveTemplate(templateName, loadedTemplates) {
+    //Look up a template in the provided object (presumably handed to us by whatever
+    //is loaded in the `templates` module). The template name can contain '/' or '.'
+    //to indicate a 'path' in the template object hierarchy:
+    //
+    //templateName == 'post', return loadedTemplates['post_html'] or ...['post_jade'],
+    //
+    //templateName == 'some/nested/post' or 'some.nested.post', return
+    //loadedTemplates.some.nested['post_html'] or ...['post_jade'],
+    //(suffix depends on the template engine)
+    var suffix = '_' + render.getTemplateType(meta.data.templateEngine).fileType,
+        parts = templateName.replace(/\//g, '.').split('.'),
+        found = loadedTemplates;
+
+    for (var i=0; i<parts.length; i++) {
+        found = found && found[parts[i] + ((i == parts.length - 1) ? suffix : '')];
+    }
+
+    return found;
+}
+
 function extractDescription(desc) {
     desc = (desc || '').trim();
     var text = /[^\r\n]*/.exec(desc);
@@ -302,7 +323,7 @@ publish.mixinData = function (srcPath, publishData) {
 };
 
 publish.renderPost = function (srcPath, publishedData) {
-    var postPath, srcDir;
+    var postPath, srcDir, postTemplate;
 
     if (fs.statSync(srcPath).isDirectory()) {
         srcDir = srcPath;
@@ -318,7 +339,13 @@ publish.renderPost = function (srcPath, publishedData) {
     }
 
     //Write out the post in HTML form.
-    convert(templates.text.year.month.day.title.index_html, publishedData,
+    if (publishedData.headers.template) {
+        postTemplate = resolveTemplate(publishedData.headers.template, templates.text);
+    }
+    if (!postTemplate) {
+        postTemplate = templates.text.year.month.day.title[templateField];
+    }
+    convert(postTemplate, publishedData,
             path.join(postPath, 'index.html'), '../../../..');
 };
 

--- a/lib/render.js
+++ b/lib/render.js
@@ -39,4 +39,15 @@ render.fromFile = function (templatePath, data) {
     return render(fs.readFileSync(templatePath, 'utf8'), data);
 };
 
+render.getTemplateType = function (engine) {
+    //Given a string (generally from meta.data.templateEngine defining the template
+    //engine, return an object containing string IDs for the module to load and
+    //the field in the `templates` module in which we'll find our loaded template(s)
+    if (engine && engine.toLowerCase() == 'jade') {
+        return {type: 'jade', template: 'index_jade', fileType: 'jade'};
+    } else {
+        return {type: 'mustache', template: 'index_html', fileType: 'html'};
+    }
+};
+
 module.exports = render;


### PR DESCRIPTION
Here's the code I talked about in issue #5. It's based on the current master, so if you decide to go whole hog and merge everything I've submitted, there'll be a conflict or two. If you _do_ want to merge everything, let me know, and I can create a single big pull request that includes everything from my local main development branch.

Anyway, as you can see in the other issue, all this does is allow you to add a YAML header like `template: someTemplate`, and it returns the object at `templates.text.someTemplate_html`. You can do dotted or slashed paths to templates deeper in the hierarchy too: `template: path.to.post` or `template: path/to/post` return whatever's in `templates.text.path.to.post_html`.
